### PR TITLE
Adding denoised options to Wiser CRF Tagger

### DIFF
--- a/wiser/models/crf_tagger.py
+++ b/wiser/models/crf_tagger.py
@@ -121,3 +121,94 @@ class WiserCrfTagger(CrfTagger):
         if metadata is not None:
             output["words"] = [x["words"] for x in metadata]
         return output
+
+
+@Model.register("denoised_wiser_crf_tagger")
+class WiserCrfTagger(WiserCrfTagger):
+
+    def __init__(self, vocab: Vocabulary,
+                 text_field_embedder: TextFieldEmbedder,
+                 encoder: Seq2SeqEncoder,
+                 label_namespace: str = "labels",
+                 feedforward: Optional[FeedForward] = None,
+                 label_encoding: Optional[str] = None,
+                 include_start_end_transitions: bool = True,
+                 constrain_crf_decoding: bool = None,
+                 calculate_span_f1: bool = None,
+                 dropout: Optional[float] = None,
+                 verbose_metrics: bool = False,
+                 initializer: InitializerApplicator = InitializerApplicator(),
+                 regularizer: Optional[RegularizerApplicator] = None,
+                 use_tags: str = False) -> None:
+
+        super().__init__(vocab, text_field_embedder, encoder,
+                         label_namespace, feedforward, label_encoding,
+                         include_start_end_transitions, constrain_crf_decoding, calculate_span_f1,
+                         dropout, verbose_metrics, initializer, regularizer, use_tags)
+
+    @overrides
+    def forward(self,  # type: ignore
+                tokens: Dict[str, torch.LongTensor],
+                tags: torch.LongTensor = None,
+                metadata: List[Dict[str, Any]] = None,
+                # pylint: disable=unused-argument
+                **kwargs) -> Dict[str, torch.Tensor]:
+        # pylint: disable=arguments-differ
+        """
+        Same signature as parent class's forward() method.
+
+        Only difference is that loss is computed as the expected log likelihood
+        using metadata, rather than tags.
+        """
+
+        embedded_text_input = self.text_field_embedder(tokens)
+        mask = util.get_text_field_mask(tokens)
+
+        if self.dropout:
+            embedded_text_input = self.dropout(embedded_text_input)
+
+        encoded_text = self.encoder(embedded_text_input, mask)
+
+        if self.dropout:
+            encoded_text = self.dropout(encoded_text)
+
+        if self._feedforward is not None:
+            encoded_text = self._feedforward(encoded_text)
+
+        logits = self.tag_projection_layer(encoded_text)
+        best_paths = self.crf.viterbi_tags(logits, mask)
+        predicted_tags = [x for x, y in best_paths]
+
+        # Just get the tags and ignore the score.
+        output = {"logits": logits, "mask": mask, "tags": predicted_tags}
+
+        unary_marginals = kwargs.get('unary_marginals')
+        pairwise_marginals = kwargs.get('pairwise_marginals')
+
+        if not self.use_tags:
+            if unary_marginals is not None:
+                ell = self.crf.denoised_expected_log_likelihood(logits=logits,
+                                                    mask=mask,
+                                                    unary_marginals=unary_marginals,
+                                                    pairwise_marginals=pairwise_marginals)
+                output["loss"] = -ell
+                
+        if tags is not None:
+            if unary_marginals is None or self.use_tags:
+                log_likelihood = self.crf(logits, tags, mask)
+                output['loss'] = -log_likelihood
+
+            # Represent viterbi tags as "class probabilities" that we can
+            # feed into the metrics
+            class_probabilities = logits * 0.
+            for i, instance_tags in enumerate(predicted_tags):
+                for j, tag_id in enumerate(instance_tags):
+                    class_probabilities[i, j, tag_id] = 1
+            for metric in self.metrics.values():
+                metric(class_probabilities, tags, mask.float())
+            if self.calculate_span_f1:
+                self._f1_metric(class_probabilities, tags, mask.float())
+
+        if metadata is not None:
+            output["words"] = [x["words"] for x in metadata]
+        return output

--- a/wiser/models/crf_tagger.py
+++ b/wiser/models/crf_tagger.py
@@ -124,7 +124,7 @@ class WiserCrfTagger(CrfTagger):
 
 
 @Model.register("denoised_wiser_crf_tagger")
-class WiserCrfTagger(WiserCrfTagger):
+class DenoisedWiserCrfTagger(WiserCrfTagger):
 
     def __init__(self, vocab: Vocabulary,
                  text_field_embedder: TextFieldEmbedder,

--- a/wiser/modules/conditional_random_field.py
+++ b/wiser/modules/conditional_random_field.py
@@ -1,9 +1,9 @@
 import torch
 from allennlp.modules.conditional_random_field import ConditionalRandomField
-import sys
-from loguru import logger
-logger.remove()
-logger.add(sys.stderr, format="{level} {level.icon} | [{time}] - {message}")
+# import sys
+# from loguru import logger
+# logger.remove()
+# logger.add(sys.stderr, format="{level} {level.icon} | [{time}] - {message}")
 
 
 class WiserConditionalRandomField(ConditionalRandomField):

--- a/wiser/modules/conditional_random_field.py
+++ b/wiser/modules/conditional_random_field.py
@@ -1,8 +1,171 @@
 import torch
 from allennlp.modules.conditional_random_field import ConditionalRandomField
+import sys
+from loguru import logger
+logger.remove()
+logger.add(sys.stderr, format="{level} {level.icon} | [{time}] - {message}")
 
 
 class WiserConditionalRandomField(ConditionalRandomField):
+    def denoise_unary(
+            self,
+            unary_marginals: torch.FloatTensor) -> torch.FloatTensor:
+        """
+        make unary_marginals becomes one-hot.
+        """
+        # logger.debug(unary_marginals.shape)
+        # logger.debug(unary_marginals)
+        ones_unary_marginals = torch.zeros_like(unary_marginals)
+        ones_unary_marginals[torch.arange(0, unary_marginals.shape[0]), torch.argmax(unary_marginals, dim=1)] = 1.
+        # logger.debug(ones_unary_marginals.shape)
+        # logger.debug(ones_unary_marginals)
+        assert ones_unary_marginals.shape == unary_marginals.shape # check same shape (bsz, num_class)
+        assert (torch.sum(ones_unary_marginals, dim=1) == 1).all() # check all rows add to 1
+        return ones_unary_marginals
+
+    def denoise_pairwise(
+            self,
+            curr_unary_marginals: torch.FloatTensor,
+            next_unary_marginals: torch.FloatTensor,
+            pairwise_marginals: torch.Tensor) -> torch.Tensor:
+        """
+        make pairwise_marginals becomes one-hot.
+        """
+        argmax_curr_unary_marginals = torch.argmax(curr_unary_marginals, axis=1)
+        argmax_next_unary_marginals = torch.argmax(next_unary_marginals, axis=1)
+
+        # logger.debug(f"unary_marginals for timestep t: {curr_unary_marginals}")
+        # logger.debug(f"argmax unary_marginals for timestep t: {argmax_curr_unary_marginals}")
+        # logger.debug(f"unary_marginals for timestep t + 1: {next_unary_marginals}")
+        # logger.debug(f"argmax unary_marginals for timestep t + 1: {argmax_next_unary_marginals}")
+        # logger.debug(argmax_curr_unary_marginals.shape)
+        
+        ones_pairwise_marginals = torch.zeros_like(pairwise_marginals)
+        ones_pairwise_marginals[torch.arange(0, curr_unary_marginals.shape[0]).long(), 
+                                torch.argmax(curr_unary_marginals, axis=1), 
+                                torch.argmax(next_unary_marginals, axis=1)] = 1.
+        # logger.debug(f"ones_pairwise_marginals: {ones_pairwise_marginals}")
+
+        assert ones_pairwise_marginals.shape == pairwise_marginals.shape
+        assert (torch.sum(torch.sum(ones_pairwise_marginals, dim=1), dim=1) == 1).all()
+        return ones_pairwise_marginals
+
+    def denoised_expected_log_likelihood(
+            self,
+            logits: torch.Tensor,
+            mask: torch.ByteTensor,
+            unary_marginals: torch.FloatTensor,
+            pairwise_marginals: torch.Tensor = None) -> torch.Tensor:
+        """
+        Computes the expected log likelihood of CRFs defined by batch of logits
+        with respect to a reference distribution over the random variables.
+
+        Parameters
+        ----------
+        logits : torch.Tensor, required
+            The logits that define the CRF distribution, of shape
+            ``(batch_size, seq_len, num_tags)``.
+        unary_marginals : torch.Tensor, required
+            Marginal probability that each sequence element is a particular tag,
+            according to the reference distribution. Shape is
+            ``(batch_size, seq_len, num_tags)``.
+        pairwise_marginals : torch.Tensor, optional (default = ``None``)
+            Marginal probability that each pair of sequence elements is a
+            particular pair of tags, according to the reference distribution.
+            Shape is ``(batch_size, seq_len - 1, num_tags, num_tags)``, so
+            pairwise_marginals[:, 0, 0, 0] is the probability that the first
+            and second tags in each sequence are both 0,
+            pairwise_marginals[:, 1, 0, 0] is the probability that the second
+            and and third tags in each sequence are both 0, etc. If None,
+            pairwise_marginals will be computed from unary_marginals assuming
+            that they are independent in the reference distribution.
+        mask : ``torch.ByteTensor``
+            The text field mask for the input tokens of shape
+            ``(batch_size, seq_len)``.
+        """
+        batch_size, seq_len, num_tags = logits.size()
+
+        # We compute the partition function before rearranging the inputs
+        partition = self._input_likelihood(logits, mask)
+        # Transpose batch size and sequence dimensions
+        logits = logits.transpose(0, 1).contiguous()                 # (seq_len, batch_size, num_tags)
+        mask = mask.float().transpose(0, 1).contiguous()             # (seq_len, batch_size)
+
+        unary_marginals = unary_marginals.transpose(0, 1)            # (seq_len, batch_size, num_tags)
+        unary_marginals = unary_marginals.contiguous()
+        if pairwise_marginals is not None:
+            pairwise_marginals = pairwise_marginals.transpose(0, 1)  # (seq_len - 1, batch_size, num_tags, num_tags)
+            pairwise_marginals = pairwise_marginals.contiguous()
+        else:
+            pairwise_marginals = torch.zeros(
+                                    (seq_len - 1, batch_size, num_tags, num_tags),
+                                    device=logits.device.type)
+
+            for i in range(seq_len - 1):
+                for j in range(batch_size):
+                    temp1 = unary_marginals[i, j]
+                    temp2 = unary_marginals[i+1, j]
+                    temp = torch.ger(temp1, temp2)
+                    pairwise_marginals[i, j, :, :] = temp
+
+        # Start with the transition scores from start_tag to the
+        # first tag in each input
+        if self.include_start_end_transitions:
+            temp = self.start_transitions.unsqueeze(0)               # (1, num_tags)
+            # temp = temp * unary_marginals[0]                         # (batch_size, num_tags) # noise-aware
+            ones_unary_marginals = self.denoise_unary(unary_marginals[0])
+            temp = temp * ones_unary_marginals                       # (batch_size, num_tags)
+            score = temp.sum(dim=1)                                  # (batch_size,)
+        else:
+            score = torch.zeros((batch_size,), device=logits.device.type) # (batch_size,)
+
+        # Add up the scores for the expected transitions and all
+        # the inputs but the last
+        for i in range(seq_len - 1):
+            # Adds contributions from logits
+            # temp = logits[i] * unary_marginals[i]                    # (batch_size, num_tags) # noise-aware
+            ones_unary_marginals = self.denoise_unary(unary_marginals[i])
+            temp = logits[i] * ones_unary_marginals
+            temp = temp.sum(dim=1)                                   # (batch_size,)
+            score += temp * mask[i]
+
+            # Adds contributions from transitions from i to i+1
+            temp = self.transitions.unsqueeze(0)                     # (1, num_tags, num_tags)
+            ones_pairwise_marginals = self.denoise_pairwise(unary_marginals[i],
+                                                            unary_marginals[i + 1],
+                                                            pairwise_marginals[i])
+            temp = temp * ones_pairwise_marginals                    # (batch_size, num_tags, num_tags)
+            # temp = temp * pairwise_marginals[i]                      # (batch_size, num_tags, num_tags) # noise-aware
+            temp = temp.sum(dim=2).sum(dim=1)                        # (batch_size,)
+            score += temp * mask[i+1]
+
+        # Transition from last state to "stop" state.
+        # Computes score of transitioning to `stop_tag` from
+        # each last token.
+        if self.include_start_end_transitions:
+            # To start, we need to find the last token for
+            # each instance.
+            index0 = mask.sum(dim=0).long() - 1                      # (batch_size,)
+            index1 = torch.arange(0, batch_size, dtype=torch.long)   # (batch_size,)
+            last_marginals = unary_marginals[index0, index1, :]      # (batch_size, num_tags)
+
+            temp = self.end_transitions.unsqueeze(0)                 # (1, num_tags)
+            # temp = temp * last_marginals                             # (batch_size, num_tags) # noise-aware
+            ones_unary_marginals = self.denoise_unary(last_marginals)
+            temp = temp * ones_unary_marginals
+            temp = temp.sum(dim=1)                                   # (batch_size,)
+            score += temp
+
+        # Adds the last input if it's not masked.
+        # last_scores = logits[-1] * unary_marginals[-1]               # (batch_size, num_tags) # remove noise-aware
+        ones_unary_marginals = self.denoise_unary(unary_marginals[-1])
+        last_scores = logits[-1] * ones_unary_marginals
+        last_scores = last_scores.sum(dim= 1)                         # (batch_size,)
+        score += last_scores * mask[-1]
+        
+        # Finally we subtract partition function and return sum
+        return torch.sum(score - partition)
+
     def expected_log_likelihood(
             self,
             logits: torch.Tensor,
@@ -65,7 +228,7 @@ class WiserConditionalRandomField(ConditionalRandomField):
         # first tag in each input
         if self.include_start_end_transitions:
             temp = self.start_transitions.unsqueeze(0)               # (1, num_tags)
-            temp = temp * unary_marginals[0]                         # (batch_size, num_tags)
+            temp = temp * unary_marginals[0]                         # (batch_size, num_tags) # noise-aware
             score = temp.sum(dim=1)                                  # (batch_size,)
         else:
             score = torch.zeros((batch_size,), device=logits.device.type) # (batch_size,)
@@ -74,13 +237,13 @@ class WiserConditionalRandomField(ConditionalRandomField):
         # the inputs but the last
         for i in range(seq_len - 1):
             # Adds contributions from logits
-            temp = logits[i] * unary_marginals[i]                    # (batch_size, num_tags)
+            temp = logits[i] * unary_marginals[i]                    # (batch_size, num_tags) # noise-aware
             temp = temp.sum(dim=1)                                   # (batch_size,)
             score += temp * mask[i]
 
             # Adds contributions from transitions from i to i+1
             temp = self.transitions.unsqueeze(0)                     # (1, num_tags, num_tags)
-            temp = temp * pairwise_marginals[i]                      # (batch_size, num_tags, num_tags)
+            temp = temp * pairwise_marginals[i]                      # (batch_size, num_tags, num_tags) # noise-aware
             temp = temp.sum(dim=2).sum(dim=1)                        # (batch_size,)
             score += temp * mask[i+1]
 
@@ -95,14 +258,14 @@ class WiserConditionalRandomField(ConditionalRandomField):
             last_marginals = unary_marginals[index0, index1, :]      # (batch_size, num_tags)
 
             temp = self.end_transitions.unsqueeze(0)                 # (1, num_tags)
-            temp = temp * last_marginals                             # (batch_size, num_tags)
+            temp = temp * last_marginals                             # (batch_size, num_tags) # noise-aware
             temp = temp.sum(dim=1)                                   # (batch_size,)
             score += temp
 
         # Adds the last input if it's not masked.
-        last_scores = logits[-1] * unary_marginals[-1]               # (batch_size, num_tags)
-        last_scores = last_scores.sum(dim=1)                         # (batch_size,)
+        last_scores = logits[-1] * unary_marginals[-1]               # (batch_size, num_tags) # remove noise-aware
+        last_scores = last_scores.sum(dim= 1)                         # (batch_size,)
         score += last_scores * mask[-1]
-
+        
         # Finally we subtract partition function and return sum
         return torch.sum(score - partition)


### PR DESCRIPTION
Making wiser CRF tagger non-noise-aware.
Here are the two main changes:
1. `crf_tagger.py`: adding DenoisedWiserCrfTagger class.
2. `conditional_random_field.py`: adding `denoised_expected_log_likelihood` function and two other helper functions that make unary and pairwise marginals become one-hot. 